### PR TITLE
Fix iTerm2 not cd-ing to Finder directory

### DIFF
--- a/open_iterm2_here.scpt
+++ b/open_iterm2_here.scpt
@@ -8,8 +8,8 @@ end try
 results
 
 tell application "iTerm2"
-    create window with default profile
-    tell current session of first window
-        write text "cd '" & results & "'"
-    end tell
+  set newWindow to (create window with default profile)
+  tell current session of newWindow
+    write text "cd '" & results & "'"
+  end tell
 end tell


### PR DESCRIPTION
When using iTerm2 instead of Terminal, with an iTerm2 window already open, the `cd` command wasn't being run in the newly opened window. This makes sure that it is.